### PR TITLE
Initial support for OPDS Progression

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ## Active
 
 - [OPDS 2.0](opds-2.0.md)
-- [Authentication for OPDS 1.0](authentication-for-opds-1.0.md)
+- [OPDS Authentication 1.0](authentication-for-opds-1.0.md)
+- [OPDS Progression 1.0](opds-progression-1.0.md)
 - [Open Distribution to Libraries 1.0](odl-1.0.md)
 - [OPDS User Profile 1.0](opds-user-profile-1.0.md)
 

--- a/opds-progression-1.0.md
+++ b/opds-progression-1.0.md
@@ -67,7 +67,7 @@ Fragments are extensible by nature but the following well-known fragments have b
 
 ### Examples
 
-*Example 2: Progression in an EPUB*
+*Example 3: Progression in an EPUB*
 
 ```json
 {
@@ -80,7 +80,7 @@ Fragments are extensible by nature but the following well-known fragments have b
 }
 ```
 
-*Example 3: Progression in an EPUB with Media Overlays*
+*Example 4: Progression in an EPUB with Media Overlays*
 
 ```json
 {
@@ -94,7 +94,7 @@ Fragments are extensible by nature but the following well-known fragments have b
 }
 ```
 
-*Example 4: Progression in a PDF*
+*Example 5: Progression in a PDF*
 
 ```json
 {
@@ -108,7 +108,7 @@ Fragments are extensible by nature but the following well-known fragments have b
 }
 ```
 
-*Example 5: Progression in an audiobook*
+*Example 6: Progression in an audiobook*
 
 ```json
 {

--- a/opds-progression-1.0.md
+++ b/opds-progression-1.0.md
@@ -43,6 +43,7 @@ When authentication is required, OPDS Catalogs should use an `authenticate` hint
 
 | Key | Definition | Format | Required |
 | --- | ---------- | ------ | -------- |
+| `title` | Contains text that can be relevant to identify or contextualize the progression. | String | No |
 | `modified` | Timestamp for the last-known progression. | ISO 8601 time and date | Yes |
 | `device` | Identifies the device that provided the last-known progression. | [Device Object](#device-object) | Yes |
 | `progression` | Total progression in the publication expressed as a percentage (%). | Float between 0 and 1 | Yes |
@@ -71,6 +72,7 @@ Fragments are extensible by nature but the following well-known fragments have b
 
 ```json
 {
+  "title": "Chapter 1 - A New Dawn",
   "modified": "2026-01-27T11:00:00Z",
   "device": {
     "id": "urn:uuid:019c0047-cc8d-7ec4-a3c3-938ccadc020a",
@@ -84,6 +86,7 @@ Fragments are extensible by nature but the following well-known fragments have b
 
 ```json
 {
+  "title": "Chapter 1 - A New Dawn",
   "modified": "2026-01-28T00:24:00Z",
   "device": {
     "id": "urn:uuid:019c0047-cc8d-7ec4-a3c3-938ccadc020a",
@@ -112,6 +115,7 @@ Fragments are extensible by nature but the following well-known fragments have b
 
 ```json
 {
+  "title": "Part 4",
   "modified": "2025-12-25T12:00:00Z",
   "device": {
     "id": "urn:uuid:019c0049-6e8c-745c-adb1-5b03f8ad50c4",

--- a/opds-progression-1.0.md
+++ b/opds-progression-1.0.md
@@ -15,7 +15,7 @@ It can be detected using:
 
 ```json
 {
-  "href": "https://example.com/1/position",
+  "href": "https://example.com/019c0435-5361-7e59-89b7-4ee01a6d87b8/progression",
   "type": "application/opds-progression+json",
   "rel": "http://opds-spec.org/progression"
 }
@@ -27,7 +27,7 @@ When authentication is required, OPDS Catalogs should use an `authenticate` hint
 
 ```json
 {
-  "href": "https://example.com/1/position",
+  "href": "https://example.com/019c0435-5361-7e59-89b7-4ee01a6d87b8/progression",
   "type": "application/opds-progression+json",
   "rel": "http://opds-spec.org/progression",
   "properties": {
@@ -52,10 +52,10 @@ Fragments are extensible by nature but the following well-known fragments have b
 
 | Specification | Scope | Examples |
 | ------------- | ----- | ------- |
-| [HTML](https://html.spec.whatwg.org/) | HTML | `id` |
+| [HTML](https://html.spec.whatwg.org/) | HTML | `#id` |
 | [Scroll to Text Fragment](https://wicg.github.io/scroll-to-text-fragment/) | Text |  `#:~:text=an%20example` |
-| [Media Fragment URI 1.0](https://www.w3.org/TR/media-frags/) | Audio, Video and Images | `t=67`, `xywh=160,120,320,240`|
-| [PDF](http://tools.ietf.org/rfc/rfc3778) | PDF | `page=12` |
+| [Media Fragment URI 1.0](https://www.w3.org/TR/media-frags/) | Audio, Video and Images | `#t=67`, `#xywh=160,120,320,240`|
+| [PDF](http://tools.ietf.org/rfc/rfc3778) | PDF | `#page=12` |
 
 ### Device Object
 
@@ -90,7 +90,7 @@ Fragments are extensible by nature but the following well-known fragments have b
     "name": "Ebook Reader (Pixel 10 Pro)"
   },
   "progression": 0.0174920,
-  "fragments": ["t=40.274", "#par36"]
+  "fragments": ["#t=40.274", "#par36"]
 }
 ```
 
@@ -104,7 +104,7 @@ Fragments are extensible by nature but the following well-known fragments have b
     "name": "Web Reader"
   },
   "progression": 0.048204,
-  "fragments": ["page=17"]
+  "fragments": ["#page=17"]
 }
 ```
 
@@ -118,7 +118,7 @@ Fragments are extensible by nature but the following well-known fragments have b
     "name": "Audiobook Player (Sonos Era 300)"
   },
   "progression": 0.72370325,
-  "fragments": ["t=849.250"]
+  "fragments": ["#t=849.250"]
 }
 ```
 

--- a/opds-progression-1.0.md
+++ b/opds-progression-1.0.md
@@ -46,7 +46,7 @@ When authentication is required, OPDS Catalogs should use an `authenticate` hint
 | `modified` | Timestamp for the last-known progression. | ISO 8601 time and date | Yes |
 | `device` | Identifies the device that provided the last-known progression. | [Device Object](#device-object) | Yes |
 | `progression` | Total progression in the publication expressed as a percentage (%). | Float between 0 and 1 | Yes |
-| `fragments` | Media-specific fragments. | Array of fragments using strings | No |
+| `references` | References inside the publication. | Array of URI references | No |
 
 Fragments are extensible by nature but the following well-known fragments have been identified while writing up this document:
 
@@ -90,7 +90,7 @@ Fragments are extensible by nature but the following well-known fragments have b
     "name": "Ebook Reader (Pixel 10 Pro)"
   },
   "progression": 0.0174920,
-  "fragments": ["#t=40.274", "#par36"]
+  "references": ["#t=40.274", "chapter1.html#par36"]
 }
 ```
 
@@ -104,7 +104,7 @@ Fragments are extensible by nature but the following well-known fragments have b
     "name": "Web Reader"
   },
   "progression": 0.048204,
-  "fragments": ["#page=17"]
+  "references": ["#page=17"]
 }
 ```
 
@@ -118,7 +118,7 @@ Fragments are extensible by nature but the following well-known fragments have b
     "name": "Audiobook Player (Sonos Era 300)"
   },
   "progression": 0.72370325,
-  "fragments": ["#t=849.250"]
+  "references": ["#t=849.250"]
 }
 ```
 

--- a/opds-progression-1.0.md
+++ b/opds-progression-1.0.md
@@ -1,0 +1,130 @@
+# OPDS Progression 1.0
+
+OPDS Progression 1.0 defines a JSON based API to fetch and update the last known progression in an OPDS publication.
+
+## Discovery
+
+A progression service is tied to a specific publication and can be discovered in its links using either OPDS 1.x or 2.0.
+
+It can be detected using: 
+
+- `http://opds-spec.org/progression` as its `rel` value
+- and `application/opds-progression+json` as its media type
+
+*Example 1: Link to a progression service in OPDS 2.0*
+
+```json
+{
+  "href": "https://example.com/1/position",
+  "type": "application/opds-progression+json",
+  "rel": "http://opds-spec.org/progression"
+}
+```
+
+When authentication is required, OPDS Catalogs should use an `authenticate` hint to avoid unnecessary round-trips.
+
+*Example 2: Link that requires authentication*
+
+```json
+{
+  "href": "https://example.com/1/position",
+  "type": "application/opds-progression+json",
+  "rel": "http://opds-spec.org/progression",
+  "properties": {
+    "authenticate": {
+      "href": "https://example.com/authentication.json",
+      "type": "application/opds-authentication+json"
+    }
+  }
+}
+```
+
+## Progression Document
+
+| Key | Definition | Format | Required |
+| --- | ---------- | ------ | -------- |
+| `modified` | Timestamp for the last-known progression. | ISO 8601 time and date | Yes |
+| `device` | Identifies the device that provided the last-known progression. | [Device Object](#device-object) | Yes |
+| `progression` | Total progression in the publication expressed as a percentage (%). | Float between 0 and 1 | Yes |
+| `fragments` | Media-specific fragments. | Array of fragments using strings | No |
+
+Fragments are extensible by nature but the following well-known fragments have been identified while writing up this document:
+
+| Specification | Scope | Examples |
+| ------------- | ----- | ------- |
+| [HTML](https://html.spec.whatwg.org/) | HTML | `id` |
+| [Scroll to Text Fragment](https://wicg.github.io/scroll-to-text-fragment/) | Text |  `#:~:text=an%20example` |
+| [Media Fragment URI 1.0](https://www.w3.org/TR/media-frags/) | Audio, Video and Images | `t=67`, `xywh=160,120,320,240`|
+| [PDF](http://tools.ietf.org/rfc/rfc3778) | PDF | `page=12` |
+
+### Device Object
+
+| Key | Definition | Format | Required |
+| --- | ---------- | ------ | -------- |
+| `id` | A unique identifier, not meant to be displayed to the user. | URI | Yes |
+| `name` | A device name, meant to be displayed to the user. | String | Yes |
+
+
+### Examples
+
+*Example 2: Progression in an EPUB*
+
+```json
+{
+  "modified": "2026-01-27T11:00:00Z",
+  "device": {
+    "id": "urn:uuid:019c0047-cc8d-7ec4-a3c3-938ccadc020a",
+    "name": "Ebook Reader (Pixel 10 Pro)"
+  },
+  "progression": 0.0174920
+}
+```
+
+*Example 3: Progression in an EPUB with Media Overlays*
+
+```json
+{
+  "modified": "2026-01-28T00:24:00Z",
+  "device": {
+    "id": "urn:uuid:019c0047-cc8d-7ec4-a3c3-938ccadc020a",
+    "name": "Ebook Reader (Pixel 10 Pro)"
+  },
+  "progression": 0.0174920,
+  "fragments": ["t=40.274", "#par36"]
+}
+```
+
+*Example 4: Progression in a PDF*
+
+```json
+{
+  "modified": "2026-01-28T19:00:00Z",
+  "device": {
+    "id": "https://reader.example.com",
+    "name": "Web Reader"
+  },
+  "progression": 0.048204,
+  "fragments": ["page=17"]
+}
+```
+
+*Example 5: Progression in an audiobook*
+
+```json
+{
+  "modified": "2025-12-25T12:00:00Z",
+  "device": {
+    "id": "urn:uuid:019c0049-6e8c-745c-adb1-5b03f8ad50c4",
+    "name": "Audiobook Player (Sonos Era 300)"
+  },
+  "progression": 0.72370325,
+  "fragments": ["t=849.250"]
+}
+```
+
+## Interactions
+
+| HTTP Verb | Expected behavior | 
+| --------- | ----------------- | 
+| `GET` | Client requests the last-known progression from the server. If this information is more up-to-date than what the client has, it requests to the user if they'd like to jump to the new progression. |
+| `PUT` | Client sends the last-known progression to the server. Server determines whether the progression should be updated and returns a progression. |

--- a/opds-progression-1.0.md
+++ b/opds-progression-1.0.md
@@ -192,6 +192,25 @@ In general, it is recommended to use more specific references over more generic 
 
 # Interactions
 
+## Payload
+
+Successful interactions must either return a [Progression Document](#progression-document) or an empty payload (when a progression hasn't been communicated to the service yet).
+
+If the interaction returns a `401 Unauthorized` code, the payload must contain an [OPDS Authentication Document](https://drafts.opds.io/authentication-for-opds-1.0.html).
+
+For any other error, the payload must contain a [Problem Details Object](https://datatracker.ietf.org/doc/html/rfc7807) with a `type` and `title`.
+
+This document defines a list of values for that implementations are strongly advised to follow.
+
+*Example 10: Problem Details Object*
+
+```json
+{
+  "type": "https://registry.opds.io/error#progression-date",
+  "title": "A more recent progression point is already available."
+}
+```
+
 ## Fetching a progression
 
 | HTTP Verb | Expected behavior | 
@@ -220,14 +239,15 @@ In general, it is recommended to use more specific references over more generic 
 
 ### Failure codes
 
-| HTTP Status Code | 
-| ---------------- | 
-| `400 Bad Request` |
-| `403 Forbidden` |
-| `409 Conflict` |
+| HTTP Status Code | Type | Title |
+| ---------------- | ---- | ----- |
+| `400 Bad Request` | <https://registry.opds.io/error#progression-invalid-payload> | Progression could not be updated due to an invalid payload. |
+| `403 Forbidden` | <https://registry.opds.io/error#progression-incorrect-user> | Progression could not be updated for the current user. |
+| `403 Forbidden` | <https://registry.opds.io/error#progression-locked> | Progression can no longer be updated for this publication. |
+| `409 Conflict` | <https://registry.opds.io/error#progression-date> | A more recent progression point is already available. |
 
 # Appendix A - JSON Schema
 
-A JSON Schema is available under version control at https://github.com/opds-community/drafts/blob/master/schema/progression.schema.json
+A JSON Schema is available under version control at <https://github.com/opds-community/drafts/blob/master/schema/progression.schema.json>
 
-For the purpose of validating an OPDS Authentication Document, use the following URL: https://drafts.opds.io/schema/progression.schema.json
+For the purpose of validating an OPDS Authentication Document, use the following URL: <https://drafts.opds.io/schema/progression.schema.json>

--- a/opds-progression-1.0.md
+++ b/opds-progression-1.0.md
@@ -2,14 +2,14 @@
 
 OPDS Progression 1.0 defines a JSON based API to fetch and update the last known progression in an OPDS publication.
 
-## Discovery
+# Auto-discovery
 
-A progression service is tied to a specific publication and can be discovered in its links using either OPDS 1.x or 2.0.
+A progression service is tied to a specific publication and can be discovered in links using either OPDS 1.x or 2.0.
 
 It can be detected using: 
 
-- `http://opds-spec.org/progression` as its `rel` value
-- and `application/opds-progression+json` as its media type
+- `http://opds-spec.org/progression` for `rel` value
+- and `application/opds-progression+json` for the media type
 
 *Example 1: Link to a progression service in OPDS 2.0*
 
@@ -39,6 +39,8 @@ When authentication is required, OPDS Catalogs should use an `authenticate` hint
 }
 ```
 
+# Syntax
+
 ## Progression Document
 
 | Key | Definition | Format | Required |
@@ -49,7 +51,20 @@ When authentication is required, OPDS Catalogs should use an `authenticate` hint
 | `progression` | Total progression in the publication expressed as a percentage (%). | Float between 0 and 1 | Yes |
 | `references` | References inside the publication. | Array of URI references | No |
 
-Fragments are extensible by nature but the following well-known fragments have been identified while writing up this document:
+## References
+
+> [!NOTE]
+> WHATWG is in the process of integrating scroll to text fragments into the HTML specification. Once that's done, we'll remove this reference to the WICG draft.
+
+References are meant to refine the progression expressed in `progression`.
+
+Common use-cases for these references include:
+
+- a media fragment for the entire publication (`#t=67`)
+- a path into a packaged publication with an optional media fragment (`chapter1.html#par26`)
+- or a full URL with an optional media fragment (`https://example.com/chapter1#par26`)
+
+This document has identified the following specifications for media fragments:
 
 | Specification | Scope | Examples |
 | ------------- | ----- | ------- |
@@ -58,7 +73,11 @@ Fragments are extensible by nature but the following well-known fragments have b
 | [Media Fragment URI 1.0](https://www.w3.org/TR/media-frags/) | Audio, Video and Images | `#t=67`, `#xywh=160,120,320,240`|
 | [PDF](http://tools.ietf.org/rfc/rfc3778) | PDF | `#page=12` |
 
-### Device Object
+This document does not provide processing rules for clients or servers.
+
+In general, it is recommended to use more specific references over more generic one and to always fallback to `progression` when none of the URI references included in `references` can't be resolved.
+
+## Device Object
 
 | Key | Definition | Format | Required |
 | --- | ---------- | ------ | -------- |
@@ -66,9 +85,10 @@ Fragments are extensible by nature but the following well-known fragments have b
 | `name` | A device name, meant to be displayed to the user. | String | Yes |
 
 
-### Examples
+## Examples
 
 *Example 3: Progression in an EPUB*
+
 
 ```json
 {
@@ -126,9 +146,16 @@ Fragments are extensible by nature but the following well-known fragments have b
 }
 ```
 
-## Interactions
+# Interactions
 
 | HTTP Verb | Expected behavior | 
 | --------- | ----------------- | 
 | `GET` | Client requests the last-known progression from the server. If this information is more up-to-date than what the client has, it requests to the user if they'd like to jump to the new progression. |
 | `PUT` | Client sends the last-known progression to the server. Server determines whether the progression should be updated and returns a progression. |
+
+
+# Appendix A - JSON Schema
+
+A JSON Schema is available under version control at https://github.com/opds-community/drafts/blob/master/schema/progression.schema.json
+
+For the purpose of validating an OPDS Authentication Document, use the following URL: https://drafts.opds.io/schema/progression.schema.json

--- a/opds-progression-1.0.md
+++ b/opds-progression-1.0.md
@@ -71,7 +71,6 @@ This document has identified the following specifications for media fragments:
 | [HTML](https://html.spec.whatwg.org/) | HTML | `#id` |
 | [Scroll to Text Fragment](https://wicg.github.io/scroll-to-text-fragment/) | Text |  `#:~:text=an%20example` |
 | [Media Fragment URI 1.0](https://www.w3.org/TR/media-frags/) | Audio, Video and Images | `#t=67`, `#xywh=160,120,320,240`|
-| [PDF](http://tools.ietf.org/rfc/rfc3778) | PDF | `#page=12` |
 
 This document does not provide processing rules for clients or servers.
 
@@ -98,7 +97,8 @@ In general, it is recommended to use more specific references over more generic 
     "id": "urn:uuid:019c0047-cc8d-7ec4-a3c3-938ccadc020a",
     "name": "Ebook Reader (Pixel 10 Pro)"
   },
-  "progression": 0.0174920
+  "progression": 0.0174920,
+  "references": ["chapter1.html#:~:text=It%20was%20expected"]
 }
 ```
 
@@ -117,7 +117,7 @@ In general, it is recommended to use more specific references over more generic 
 }
 ```
 
-*Example 5: Progression in a PDF*
+*Example 5: Progression in a PDF on a Web Reader*
 
 ```json
 {
@@ -126,8 +126,7 @@ In general, it is recommended to use more specific references over more generic 
     "id": "https://reader.example.com",
     "name": "Web Reader"
   },
-  "progression": 0.048204,
-  "references": ["#page=17"]
+  "progression": 0.048204
 }
 ```
 
@@ -155,8 +154,8 @@ In general, it is recommended to use more specific references over more generic 
     "id": "https://reader.example.com",
     "name": "Web Reader"
   },
-  "progression": 0.029402,
-  "references": ["https://example.com/chapter1"]
+  "progression": 0.1,
+  "references": ["https://example.com/chapter1#:~:text=It%20was%20expected"]
 }
 ```
 

--- a/opds-progression-1.0.md
+++ b/opds-progression-1.0.md
@@ -45,7 +45,7 @@ When authentication is required, OPDS Catalogs should use an `authenticate` hint
 
 | Key | Definition | Format | Required |
 | --- | ---------- | ------ | -------- |
-| `title` | Contains text that can be relevant to identify or contextualize the progression. | String | No |
+| `title` | Contains text that can be relevant to identify or contextualize the progression, such as a chapter title. | String | No |
 | `modified` | Timestamp for the last-known progression. | ISO 8601 time and date | Yes |
 | `device` | Identifies the device that provided the last-known progression. | [Device Object](#device-object) | Yes |
 | `progression` | Total progression in the publication expressed as a percentage (%). | Float between 0 and 1 | Yes |
@@ -75,7 +75,7 @@ This document has identified the following specifications for media fragments:
 
 This document does not provide processing rules for clients or servers.
 
-In general, it is recommended to use more specific references over more generic one and to always fallback to `progression` when none of the URI references included in `references` can't be resolved.
+In general, it is recommended to use more specific references over more generic one and to always fallback to `progression` when none of the URI references included in `references` can be resolved.
 
 ## Device Object
 
@@ -250,4 +250,4 @@ This document defines a list of values for that implementations are strongly adv
 
 A JSON Schema is available under version control at <https://github.com/opds-community/drafts/blob/master/schema/progression.schema.json>
 
-For the purpose of validating an OPDS Authentication Document, use the following URL: <https://drafts.opds.io/schema/progression.schema.json>
+For the purpose of validating an OPDS Progression Document, use the following URL: <https://drafts.opds.io/schema/progression.schema.json>

--- a/opds-progression-1.0.md
+++ b/opds-progression-1.0.md
@@ -146,13 +146,55 @@ In general, it is recommended to use more specific references over more generic 
 }
 ```
 
+*Example 7: Progression in a Web Publication*
+
+```json
+{
+  "modified": "2026-02-01T16:00:00Z",
+  "device": {
+    "id": "https://reader.example.com",
+    "name": "Web Reader"
+  },
+  "progression": 0.029402,
+  "references": ["https://example.com/chapter1"]
+}
+```
+
 # Interactions
+
+## Fetching a progression
 
 | HTTP Verb | Expected behavior | 
 | --------- | ----------------- | 
 | `GET` | Client requests the last-known progression from the server. If this information is more up-to-date than what the client has, it requests to the user if they'd like to jump to the new progression. |
+
+### Success codes
+
+| HTTP Status Code | Payload | 
+| ---------------- | ------- | 
+| `200 OK` | [Progression Document](#progression-document) or an empty payload|
+
+
+## Updating a progression
+
+| HTTP Verb | Expected behavior | 
+| --------- | ----------------- | 
 | `PUT` | Client sends the last-known progression to the server. Server determines whether the progression should be updated and returns a progression. |
 
+### Success codes
+
+| HTTP Status Code | Payload | 
+| ---------------- | ------- | 
+| `200 OK` | [Progression Document](#progression-document) |
+| `201 Created` | [Progression Document](#progression-document) |
+
+### Failure codes
+
+| HTTP Status Code | 
+| ---------------- | 
+| `400 Bad Request` |
+| `403 Forbidden` |
+| `409 Conflict` |
 
 # Appendix A - JSON Schema
 

--- a/opds-progression-1.0.md
+++ b/opds-progression-1.0.md
@@ -71,6 +71,7 @@ This document has identified the following specifications for media fragments:
 | [HTML](https://html.spec.whatwg.org/) | HTML | `#id` |
 | [Scroll to Text Fragment](https://wicg.github.io/scroll-to-text-fragment/) | Text |  `#:~:text=an%20example` |
 | [Media Fragment URI 1.0](https://www.w3.org/TR/media-frags/) | Audio, Video and Images | `#t=67`, `#xywh=160,120,320,240`|
+| [PDF](https://www.rfc-editor.org/rfc/rfc8118.html#section-3) | PDF documents | `#page=6` |
 
 This document does not provide processing rules for clients or servers.
 
@@ -86,7 +87,7 @@ In general, it is recommended to use more specific references over more generic 
 
 ## Examples
 
-*Example 3: Progression in an EPUB*
+*Example 3: Progression in a reflowable EPUB*
 
 
 ```json
@@ -102,7 +103,7 @@ In general, it is recommended to use more specific references over more generic 
 }
 ```
 
-*Example 4: Progression in an EPUB with Media Overlays*
+*Example 4: Progression in a reflowable EPUB with Media Overlays*
 
 ```json
 {
@@ -117,7 +118,22 @@ In general, it is recommended to use more specific references over more generic 
 }
 ```
 
-*Example 5: Progression in a PDF on a Web Reader*
+*Example 5: Progression in a pre-paginated EPUB*
+
+```json
+{
+  "title": "Chapter 5 - A twist",
+  "modified": "2026-02-05T13:14:00Z",
+  "device": {
+    "id": "urn:uuid:019c0047-cc8d-7ec4-a3c3-938ccadc020a",
+    "name": "Ebook Reader (Pixel 10 Pro)"
+  },
+  "progression": 0.0528999,
+  "references": ["chapter5.html"]
+}
+```
+
+*Example 6: Progression in a PDF on a Web Reader*
 
 ```json
 {
@@ -126,11 +142,26 @@ In general, it is recommended to use more specific references over more generic 
     "id": "https://reader.example.com",
     "name": "Web Reader"
   },
-  "progression": 0.048204
+  "progression": 0.048204,
+  "references": ["#page=87"]
 }
 ```
 
-*Example 6: Progression in an audiobook*
+*Example 7: Progression in a CBZ*
+
+```json
+{
+  "modified": "2026-02-05T14:24:00Z",
+  "device": {
+    "id": "urn:uuid:019c2df6-90f8-7096-b162-a0e69cd52844",
+    "name": "Comics Reader"
+  },
+  "progression": 0.4999,
+  "references": ["page78.jxl"]
+}
+```
+
+*Example 8: Progression in an audiobook*
 
 ```json
 {
@@ -145,7 +176,7 @@ In general, it is recommended to use more specific references over more generic 
 }
 ```
 
-*Example 7: Progression in a Web Publication*
+*Example 9: Progression in a Web Publication*
 
 ```json
 {

--- a/schema/progression.schema.json
+++ b/schema/progression.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://drafts.opds.io/schema/progression.schema.json",
+  "title": "OPDS Progression Document",
+  "type": "object",
+  "properties": {
+    "modified": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "device": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uri"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ]
+    },
+    "progression": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri-references"
+      }
+    }
+  },
+  "required": [
+    "modified",
+    "device",
+    "progression"
+  ]
+}

--- a/schema/progression.schema.json
+++ b/schema/progression.schema.json
@@ -4,6 +4,9 @@
   "title": "OPDS Progression Document",
   "type": "object",
   "properties": {
+    "title": {
+      "type": "string"
+    },
     "modified": {
       "type": "string",
       "format": "date-time"

--- a/schema/progression.schema.json
+++ b/schema/progression.schema.json
@@ -37,7 +37,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "format": "uri-references"
+        "format": "uri-reference"
       }
     }
   },

--- a/schema/progression.schema.json
+++ b/schema/progression.schema.json
@@ -33,7 +33,7 @@
       "minimum": 0,
       "maximum": 1
     },
-    "refs": {
+    "references": {
       "type": "array",
       "items": {
         "type": "string",


### PR DESCRIPTION
# Goal

Synchronizing progression using OPDS has been by far the most requested features over the last few years. 

Wth this PR the goal is to provide a standardized solution that could work across many types of publications.

The document itself is fairly barebones and will be fleshed out once there's a general agreement on what it contains. The current approach is based on the minimum information required to make this work.

## Links

- [Draft document](https://github.com/opds-community/drafts/blob/progression/opds-progression-1.0.md)
- [JSON Schema](https://github.com/opds-community/drafts/blob/progression/schema/progression.schema.json)
- [Readium Locators](https://github.com/readium/architecture/tree/master/models/locators)

# Syntax

Looking at the required property, this currently means:

- a timestamp (`modified`)
- a way to identify the device that submitted the last-known progression (`device`)
- and a progression in the publication (`progression`)

The timestamp is self-explanatory.

For the device, I went for two required values:
- an `id` meant to uniquely identify a device (useful for clients/servers potentially) based on a URI
- and a `name` meant to be displayed to the user using a string

If I finished reading chapter 1 on device A, next time that my progression is synchronized on device B, it should tell the user that the progression has changed and mention that this information is coming from device A. That's what this information is for.

A client could also recognize itself using the `id` and skip all of this.

For the progression itself, a total progression in the publication in percentage (number between 0 and 1 in JSON) feels like the most universal thing.

How we calculate progression is a different story, one that could be handled through best practices as we flesh out the document further.

In addition, I've also added support for `references` which open the door to media-specific fragments suche as `page` for PDF. A list of well-known fragments has also been included.

I initially started working on this based on [Readium Locators](https://github.com/readium/architecture/tree/master/models/locators), but kept simplifying things until `progression` (`totalProgression` in Readium Locators) and `references` were the only two things left.

# Examples

*Example 3: Progression in an EPUB*

```json
{
  "modified": "2026-01-27T11:00:00Z",
  "device": {
    "id": "urn:uuid:019c0047-cc8d-7ec4-a3c3-938ccadc020a",
    "name": "Ebook Reader (Pixel 10 Pro)"
  },
  "progression": 0.0174920
}
```

*Example 4: Progression in an EPUB with Media Overlays*

```json
{
  "modified": "2026-01-28T00:24:00Z",
  "device": {
    "id": "urn:uuid:019c0047-cc8d-7ec4-a3c3-938ccadc020a",
    "name": "Ebook Reader (Pixel 10 Pro)"
  },
  "progression": 0.0174920,
  "references": ["#t=40.274", "chapter1.html#par36"]
}
```

*Example 5: Progression in a PDF using a Web Reader*

```json
{
  "modified": "2026-01-28T19:00:00Z",
  "device": {
    "id": "https://reader.example.com",
    "name": "Web Reader"
  },
  "progression": 0.048204
}
```

*Example 6: Progression in an audiobook*

```json
{
  "modified": "2025-12-25T12:00:00Z",
  "device": {
    "id": "urn:uuid:019c0049-6e8c-745c-adb1-5b03f8ad50c4",
    "name": "Audiobook Player (Sonos Era 300)"
  },
  "progression": 0.72370325,
  "references": ["#t=849.250"]
}
```